### PR TITLE
fix: optional event proto

### DIFF
--- a/src/main/proto/event.proto
+++ b/src/main/proto/event.proto
@@ -25,7 +25,7 @@ message ListEventsResponse {
   string id = 1;
   string name = 2;
   optional string description = 3;
-  double price = 4;
+  optional double price = 4;
   optional string location = 5;
   string start_date = 6;
   string end_date = 7;
@@ -39,7 +39,7 @@ message GetEventDetailsResponse {
   string id = 1;
   string name = 2;
   optional string description = 3;
-  double price = 4;
+  optional double price = 4;
   optional string location = 5;
   string start_date = 6;
   string end_date = 7;


### PR DESCRIPTION
Tagged the `price` field as optional because it can be at default value (0) causing the gRPC server to ignore this field when sending the response.